### PR TITLE
Modernize look

### DIFF
--- a/src/app/login/login.component.css
+++ b/src/app/login/login.component.css
@@ -20,11 +20,3 @@ form div input[type=text] {
 form div button {
   flex: 0 0 80px;
 }
-
-span.error {
-  color: #a00;
-}
-
-span.info {
-  color: #375;
-}

--- a/src/app/login/login.component.css
+++ b/src/app/login/login.component.css
@@ -1,24 +1,24 @@
 .popup {
-  width: 24em;
-}
-
-h1 {
-  font-size: 24px;
-  line-height: 36px;
-  background: url("/img/pinboard_32.png") no-repeat;
-  padding: 2px 48px;
-  margin: 0 0 4pt;
-  border-bottom: 1px solid #136;
+  width: 400px;
 }
 
 div label {
   line-height: 175%;
 }
 
+form div {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
 form div input[type=text] {
-  width: 20em;
-  font-family: sans-serif;
-  font-size: 11pt;
+  flex: 1 0 70px;
+  margin-right: 8px;
+}
+
+form div button {
+  flex: 0 0 80px;
 }
 
 span.error {
@@ -27,13 +27,4 @@ span.error {
 
 span.info {
   color: #375;
-}
-
-button {
-  border-width: 1px;
-  margin-left: 1em;
-}
-
-button[type=submit] {
-  border-width: 2px;
 }

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -16,7 +16,7 @@
       with this API token...</span></label>
   </div>
   <div>
-    <input id="token" name="token" type="text" size="40"
+    <input id="token" name="token" type="text"
            pattern=".+:.+" placeholder="API Token" autofocus
            [disabled]="checking" ngModel>
     <button type="submit"

--- a/src/app/options/options.component.css
+++ b/src/app/options/options.component.css
@@ -29,3 +29,13 @@ input[type=checkbox] {
 form div:last-of-type {
   margin-top: 16px;
 }
+
+@media (prefers-color-scheme: dark) {
+  .options {
+    color: #CCCCCC;
+    background-color: #232327;
+  }
+  .options h1 {
+    color: #CCCCCC;
+  }
+}

--- a/src/app/options/options.component.css
+++ b/src/app/options/options.component.css
@@ -18,12 +18,15 @@
 
 input[type=checkbox] {
   margin-right: 8px;
-  transform: scale(1.25);
-  padding: 3px;
 }
 
 .popup div button {
   float: right;
+}
+
+form div {
+  display: flex;
+  align-items: baseline;
 }
 
 form div:last-of-type {

--- a/src/app/options/options.component.css
+++ b/src/app/options/options.component.css
@@ -1,45 +1,31 @@
 .options {
   color: #555;
+  padding: 8px;
+  background-color: white;
 }
 
 .popup {
-  width: 32em;
+  width: 500px;
 }
 
 .options h1 {
-  font-size: 24pt;
+  font-size: 24px;
   font-weight: normal;
-  margin: 18pt 0 12pt;
+  margin: 18px 0 12px;
   padding: 0;
   color: #777;
 }
 
-.popup h1 {
-  font-size: 24px;
-  line-height: 36px;
-  background: url("/img/pinboard_32.png") no-repeat;
-  padding: 2px 48px;
-  margin: 0 0 18pt;
-  border-bottom: 1px solid #136;
-}
-
 input[type=checkbox] {
-  margin-right: 1em;
+  margin-right: 8px;
   transform: scale(1.25);
-  padding: 3pt;
-}
-
-hr {
-  height: 1px;
-  margin: 9pt 0;
-  padding: 0;
-  color: #999;
-  background: #999;
-  border: none;
+  padding: 3px;
 }
 
 .popup div button {
   float: right;
-  font-size: 8pt;
-  margin: 6pt 0;
+}
+
+form div:last-of-type {
+  margin-top: 16px;
 }

--- a/src/app/options/options.component.html
+++ b/src/app/options/options.component.html
@@ -12,43 +12,36 @@
          (change)="submit(form)" [disabled]="!options">
   <label for="ping">Always check and show whether pages have been bookmarked</label>
 </div>
-<hr>
 <div>
   <input type="checkbox" id="unshared" name="unshared" [ngModel]="options?.unshared"
          (change)="submit(form)" [disabled]="!options">
   <label for="unshared">Add new bookmarks as private by default</label>
 </div>
-<hr>
 <div>
   <input type="checkbox" id="toread" name="toread" [ngModel]="options?.toread"
          (change)="submit(form)" [disabled]="!options">
   <label for="toread">Add new bookmarks as unread by default</label>
 </div>
-<hr>
 <div>
   <input type="checkbox" id="meta" name="meta" [ngModel]="options?.meta"
          (change)="submit(form)" [disabled]="!options">
   <label for="meta">Use meta elements for description and tags</label>
 </div>
-<hr>
 <div>
   <input type="checkbox" id="selection" name="selection" [ngModel]="options?.selection"
          (change)="submit(form)" [disabled]="!options">
   <label for="selection">Use selected text as description</label>
 </div>
-<hr>
 <div>
   <input type="checkbox" id="blockquote" name="blockquote" [ngModel]="options?.blockquote"
          (change)="submit(form)" [disabled]="!options">
   <label for="blockquote">Wrap selected description as a block quote</label>
 </div>
-<hr>
 <div>
   <input type="checkbox" id="alpha" name="alpha" [ngModel]="options?.alpha"
          (change)="submit(form)" [disabled]="!options">
   <label for="alpha">Sort tag suggestions by name instead of frequency</label>
 </div>
-<hr>
 <div>
   Keyboard shortcut for saving pages to Pinboard Pin: <kbd>{{shortcut}}</kbd>
 </div>

--- a/src/app/pinpage/pinpage.component.css
+++ b/src/app/pinpage/pinpage.component.css
@@ -91,6 +91,7 @@ form div.submit label + button {
 }
 
 input[type=checkbox] {
+  flex: 0 0 30px;
   width: 30px;
   height: 30px;
   margin-right: 12px;

--- a/src/app/pinpage/pinpage.component.css
+++ b/src/app/pinpage/pinpage.component.css
@@ -1,14 +1,5 @@
 .popup {
-  width: 40em;
-}
-
-h1 {
-  font-size: 24px;
-  line-height: 36px;
-  background: url("/img/pinboard_32.png") no-repeat;
-  padding: 2px 48px;
-  margin: 0 0 4pt;
-  border-bottom: 1px solid #136;
+  width: 720px;
 }
 
 .error {
@@ -17,42 +8,33 @@ h1 {
   font-weight: bold;
 }
 
-button {
-  border-width: 1px;
-}
-
-button[type=submit] {
-  border-width: 2px;
-}
-
 div.buttons {
   display: flex;
   justify-content: space-between;
-  margin-top: 8pt;
-  margin-bottom: 16pt;
+  margin-top: 8px;
+  margin-bottom: 16px;
 }
 
 div.buttons button {
-  font-size: 8pt;
+  font-size: 10px;
+  max-width: 70px;
 }
 
 form div {
   display: flex;
   align-items: baseline;
-  margin: 3pt 0;
-  width: 40em;
+  margin-top: 8px;
 }
 
 form div label {
-  font-size: 10pt;
-  margin-right: 5pt;
+  margin-right: 8px;
   text-align: right;
-  width: 5em;
+  font-weight: bold;
+  width: 100px;
 }
 
 form div.info {
-  font-size: 10pt;
-  margin-bottom: 6pt;
+  margin-bottom: 8px;
 }
 
 span.info {
@@ -67,13 +49,11 @@ span.suggested {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  width: 36em;
 }
 
 span.suggested a {
-  font-size: 10pt;
   color: #136;
-  margin-right: 6pt;
+  margin-right: 8px;
   text-decoration: none;
 }
 
@@ -86,36 +66,48 @@ span.suggested a:last-child {
 }
 
 span.suggested a:nth-last-child(2) {
-  margin-right: 9pt;
-}
-
-form div input[type=checkbox] + label {
-  font-size: 11pt;
-  margin-left: 5pt;
-  margin-right: 2em;
-  text-align: left;
-  width: auto;
+  margin-right: 12px;
 }
 
 form div input[type=text],
 form div input[type=url],
 form div textarea {
-  width: 38em;
-  font-family: sans-serif;
-  font-size: 11pt;
+  flex: 1 0 70px;
 }
 
 form div.submit {
-  margin-top: 12pt;
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+}
+
+form div.submit label {
+  text-align: left;
+  width: auto;
 }
 
 form div.submit button {
-  margin-left: 8pt;
+  margin-left: 8px;
+  width: 120px;
+  padding-top: 16px;
+  padding-bottom: 12px;
 }
 
 form div.submit label + button {
   margin-left: auto;
 }
+
+input[type=checkbox] {
+  transform: scale(2);
+  margin-right: 12px;
+  margin-bottom: 4px;
+}
+
+input[type=checkbox]:focus {
+  outline: solid 1px #5cbbe7;
+  -moz-outline-radius: 6px
+}
+
 
 form div.completions {
   display: block;
@@ -123,30 +115,30 @@ form div.completions {
   margin: 0;
   padding: 0;
   height: 0;
-  width: 40em;
 }
 
 .completions ul {
   position: absolute;
-  font-size: 11pt;
   list-style-type: none;
-  bottom: 4pt;
-  left: 55pt;
-  width: 16em;
+  bottom: -2px;
+  left: 110px;
+  width: 300px;
+  max-height: 250px;
+  overflow-y: scroll;
   margin: 0;
   padding: 0;
-  background-color: #fff;
+  background-color: #FCFCF9;
   border: 1px solid #333;
-  box-shadow: 3pt 3pt 3pt #333;
-  color: #136;
+  box-shadow: 4px 4px 10px #C3C38C;
+  color: #3A529A;
   z-index: 9;
 }
 
 .completions li {
-  padding: 1pt 2pt;
+  padding: 4px;
 }
 
 .completions li.selected {
-  background-color: #136;
-  color: #ccc;
+  background-color: #3A529A;
+  color: #BEDDFB;
 }

--- a/src/app/pinpage/pinpage.component.css
+++ b/src/app/pinpage/pinpage.component.css
@@ -83,6 +83,7 @@ form div.submit button {
   width: 120px;
   padding-top: 16px;
   padding-bottom: 12px;
+  align-self: stretch;
 }
 
 form div.submit label + button {

--- a/src/app/pinpage/pinpage.component.css
+++ b/src/app/pinpage/pinpage.component.css
@@ -27,10 +27,10 @@ form div {
 }
 
 form div label {
+  flex: 0 0 100px;
   margin-right: 8px;
   text-align: right;
   font-weight: bold;
-  width: 100px;
 }
 
 form div.info {

--- a/src/app/pinpage/pinpage.component.css
+++ b/src/app/pinpage/pinpage.component.css
@@ -91,16 +91,11 @@ form div.submit label + button {
 }
 
 input[type=checkbox] {
-  transform: scale(2);
+  width: 30px;
+  height: 30px;
   margin-right: 12px;
   margin-bottom: 4px;
 }
-
-input[type=checkbox]:focus {
-  outline: solid 1px #5cbbe7;
-  -moz-outline-radius: 6px
-}
-
 
 form div.completions {
   display: block;

--- a/src/app/pinpage/pinpage.component.css
+++ b/src/app/pinpage/pinpage.component.css
@@ -37,14 +37,6 @@ form div.info {
   margin-bottom: 8px;
 }
 
-span.info {
-  color: #375;
-}
-
-span.note {
-  color: #666;
-}
-
 span.suggested {
   display: flex;
   align-items: baseline;
@@ -141,4 +133,26 @@ form div.completions {
 .completions li.selected {
   background-color: #3A529A;
   color: #BEDDFB;
+}
+
+@media (prefers-color-scheme: dark) {
+  span.suggested a {
+    color: #B882D8;
+  }
+
+  span.suggested a.added {
+    color: #aaaaaa;
+  }
+
+  .completions ul {
+    background-color: #28005C;
+    border: 1px solid #B882D8;
+    box-shadow: 4px 4px 10px #B882D8;
+    color: #CCCCCC;
+  }
+
+  .completions li.selected {
+    background-color: #3A529A;
+    color: #BEDDFB;
+  }
 }

--- a/src/app/pinpage/pinpage.component.html
+++ b/src/app/pinpage/pinpage.component.html
@@ -23,19 +23,19 @@
 <button type="button" (click)="pinboardLink('recent/')">
   Recent
 </button>
-<button type="button" (click)="pinboardLink('~/tabs/')">
+<button type="button" (click)="pinboardLink('~/tabs/')" style="max-width: 50px">
   Tab sets
 </button>
-<button type="button" (click)="saveTabs()">
+<button type="button" (click)="saveTabs()" style="max-width: 50px">
   Save tabs
 </button>
 <button type="button" (click)="pinboardLink('settings/')">
   Pinboard settings
 </button>
-<button type="button" (click)="settings()">
+<button type="button" (click)="settings()" style="max-width: 85px">
   Pinboard&nbsp;Pin settings
 </button>
-<button type="button" (click)="logOut()">
+<button type="button" (click)="logOut()" style="max-width: 45px">
   Log out
 </button>
 </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,13 +2,57 @@
 
 body {
   font-family: sans-serif;
+  font-size: 14px;
+  background-color: #fafafb;
+  padding: 0;
+  margin: 0;
 }
 
-input[type=text],
-input[type=url] {
+.popup {
+  padding: 8px;
+}
+
+.popup h1 {
+  font-size: 24px;
+  line-height: 36px;
+  background: url("/img/pinboard_32.png") no-repeat;
+  padding: 2px 48px;
+  margin: 0 0 4px;
+  border-bottom: 1px solid #136;
+}
+
+input[type=text], input[type=url], textarea {
   font-family: sans-serif;
+  font-size: 14px;
+  padding: 8px;
+  border-radius: 4px;
+  border: 1px solid #8d8585;
+  background-color: #f8f5f5;
 }
 
-div.popup {
-  background-color: white;
+button {
+  border: 1px solid #052C53;
+  border-radius: 4px;
+  background-color: #3A529A;
+  color: #BEDDFB;
+  padding: 8px;
+  font-weight: bold;
+  font-size: 12px;
+}
+
+button:hover {
+  background-color: #0D6CCA;
+}
+
+button[type=submit] {
+  border-width: 2px;
+}
+
+button:disabled, button:disabled:hover {
+  opacity: 0.4;
+}
+
+input[type=text]:focus, input[type=url]:focus, textarea:focus, button:focus, input[type=checkbox]:focus {
+  outline: solid 2px #5cbbe7;
+  -moz-outline-radius: 6px
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -6,6 +6,7 @@ body {
   background-color: #fafafb;
   padding: 0;
   margin: 0;
+  color: #101010;
 }
 
 .popup {
@@ -28,6 +29,7 @@ input[type=text], input[type=url], textarea {
   border-radius: 4px;
   border: 1px solid #3A529A;
   background-color: #f8f5f5;
+  color: #101010;
 }
 
 button {

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,3 +56,49 @@ input[type=text]:focus, input[type=url]:focus, textarea:focus, button:focus, inp
   outline: solid 2px #5cbbe7;
   -moz-outline-radius: 6px
 }
+
+span.error {
+  color: #a00;
+}
+
+span.info {
+  color: #375;
+}
+
+span.note {
+  color: #666;
+}
+
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #280034;
+    color: #CCCCCC;
+  }
+
+  .popup h1 {
+    border-bottom: 1px solid #B882D8;
+  }
+
+  input[type=text], input[type=url], textarea {
+    border: 1px solid #B882D8;
+    background-color: #28005C;
+    color: #CCCCCC;
+  }
+
+  span.info {
+    color: #4CB07E;
+  }
+
+  span.note {
+    color: #aaaaaa;
+  }
+
+  span.error {
+    color: #FF0F0F;
+  }
+
+  a, a:visited {
+    color: #5cbbe7;
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -26,7 +26,7 @@ input[type=text], input[type=url], textarea {
   font-size: 14px;
   padding: 8px;
   border-radius: 4px;
-  border: 1px solid #8d8585;
+  border: 1px solid #3A529A;
   background-color: #f8f5f5;
 }
 
@@ -50,6 +50,19 @@ button[type=submit] {
 
 button:disabled, button:disabled:hover {
   opacity: 0.4;
+}
+
+input[type=checkbox] {
+  -moz-appearance: none;
+  border-radius: 4px;
+  border: 1px solid #3A529A;
+  background-color: #f8f5f5;
+  width: 16px;
+  height: 16px;
+}
+
+input[type=checkbox]:checked {
+  background-color: #3A529A;
 }
 
 input[type=text]:focus, input[type=url]:focus, textarea:focus, button:focus, input[type=checkbox]:focus {
@@ -84,6 +97,15 @@ span.note {
     border: 1px solid #B882D8;
     background-color: #28005C;
     color: #CCCCCC;
+  }
+
+  input[type=checkbox] {
+    border: 1px solid #B882D8;
+    background-color: #28005C;
+  }
+
+  input[type=checkbox]:checked {
+    background-color: #B882D8;
   }
 
   span.info {


### PR DESCRIPTION
I use this extension quite often. Thanks for making it.
I thought it could use a fresher more modern look. So I started playing around with the CSS and came up with something I think looks nice. I also added support for dark mode.

Tested it on macOS and windows 10 with Firefox Developer Edition 79.0b9. There's no fancy new CSS features. It should also work with some older versions of Firefox. Haven't checked how far back you can go until it starts to break, though.

I replaced all size definitions with sizes in px. The mix of px and em/pt looked somewhat confusing.

![PixelSnap 2020-07-19 at 10 13 39](https://user-images.githubusercontent.com/426834/87870516-10fea000-c9a9-11ea-9060-bf0ab3218710.png)
![PixelSnap 2020-07-19 at 10 14 10](https://user-images.githubusercontent.com/426834/87870517-12c86380-c9a9-11ea-9285-e523805f50dc.png)
